### PR TITLE
Add function to clear OSCMessage

### DIFF
--- a/firmware/simple-OSC.cpp
+++ b/firmware/simple-OSC.cpp
@@ -170,6 +170,14 @@ void OSCMessage::addString(const char * value)
     }
 }
 
+///CLEAR MESSAGE
+void OSCMessage::clear()
+{
+    outputDatas = NULL;
+    outputDatasSize = 0;
+    outputTypes = NULL;
+}
+
 void OSCMessage::prinOutputDatas()
 {
     Serial.print(outputAddress);    Serial.print(" ");      Serial.print (outputDatasSize);  Serial.println(" : ");

--- a/firmware/simple-OSC.h
+++ b/firmware/simple-OSC.h
@@ -32,5 +32,6 @@ public:
     void addInt(int value);
     void addFloat(float value);
     void addString(const char * value);
+    void clear();
     void send(UDP &udp, IPAddress remoteIP, unsigned int outPort);
 };


### PR DESCRIPTION
I've added a function to clear the `OSCMessage` object so you can reuse it.

It seems to work for me, but my photon also keeps losing WiFi and cloud connections. I am not sure if it's related to these additions yet.
